### PR TITLE
fix(deps): update module github.com/sapcc/go-api-declarations to v1.21.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26
 require (
 	github.com/gophercloud/gophercloud/v2 v2.10.0
 	github.com/olekukonko/tablewriter v1.1.4
-	github.com/sapcc/go-api-declarations v1.20.1
+	github.com/sapcc/go-api-declarations v1.21.0
 	github.com/spf13/cobra v1.10.2
 )
 

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,8 @@ github.com/olekukonko/ll v0.1.7/go.mod h1:RPRC6UcscfFZgjo1nulkfMH5IM0QAYim0LfnMv
 github.com/olekukonko/tablewriter v1.1.4 h1:ORUMI3dXbMnRlRggJX3+q7OzQFDdvgbN9nVWj1drm6I=
 github.com/olekukonko/tablewriter v1.1.4/go.mod h1:+kedxuyTtgoZLwif3P1Em4hARJs+mVnzKxmsCL/C5RY=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/sapcc/go-api-declarations v1.20.1 h1:FI2JG2NXmQ1XoxEwdy0vrYPJo+sZd/IJSJVEl6W1PvE=
-github.com/sapcc/go-api-declarations v1.20.1/go.mod h1:eiRrXXUeQS5C/1kKn8/KMjk0Y0goUzgDQswj30rH0Zc=
+github.com/sapcc/go-api-declarations v1.21.0 h1:Ag6GXgJLTFdBDKmrJU4QFllQbgGSenSGeHpLuvuxeDk=
+github.com/sapcc/go-api-declarations v1.21.0/go.mod h1:eiRrXXUeQS5C/1kKn8/KMjk0Y0goUzgDQswj30rH0Zc=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=


### PR DESCRIPTION
## Summary
- Bump `github.com/sapcc/go-api-declarations` from `v1.20.1` to `v1.21.0` (main branch state).
- Replaces stale Renovate PR #102 whose branch had diverged and couldn't be auto-rebased cleanly.

## Test plan
- [ ] `go build ./...` ✅ verified locally
- [ ] CI (lint, test, CodeQL) passes